### PR TITLE
feat: replace parameter storageFile with fullPath (only) in deleteAsset

### DIFF
--- a/packages/core/src/api/storage.api.ts
+++ b/packages/core/src/api/storage.api.ts
@@ -6,8 +6,7 @@ import type {
 } from '../../declarations/satellite/satellite.did';
 import type {ListParams, ListResults} from '../types/list.types';
 import type {Satellite} from '../types/satellite.types';
-import type {ENCODING_TYPE, Storage} from '../types/storage.types';
-import {AssetKey} from '../types/storage.types';
+import type {AssetKey, ENCODING_TYPE, Storage} from '../types/storage.types';
 import {isBrowser} from '../utils/env.utils';
 import {toListParams} from '../utils/list.utils';
 import {getSatelliteActor} from './actor.api';

--- a/packages/core/src/api/storage.api.ts
+++ b/packages/core/src/api/storage.api.ts
@@ -142,16 +142,16 @@ export const listAssets = async ({
 
 export const deleteAsset = async ({
   collection,
-  storageFile,
+  asset,
   satellite
 }: {
   collection: string;
-  storageFile: Asset;
+  asset: Asset;
   satellite: Satellite;
 }): Promise<void> => {
   const actor: SatelliteActor = await getSatelliteActor(satellite);
 
-  const {fullPath} = storageFile;
+  const {fullPath} = asset;
 
   return actor.del_asset(collection, fullPath);
 };

--- a/packages/core/src/api/storage.api.ts
+++ b/packages/core/src/api/storage.api.ts
@@ -6,7 +6,8 @@ import type {
 } from '../../declarations/satellite/satellite.did';
 import type {ListParams, ListResults} from '../types/list.types';
 import type {Satellite} from '../types/satellite.types';
-import type {Asset, ENCODING_TYPE, Storage} from '../types/storage.types';
+import type {ENCODING_TYPE, Storage} from '../types/storage.types';
+import {AssetKey} from '../types/storage.types';
 import {isBrowser} from '../utils/env.utils';
 import {toListParams} from '../utils/list.utils';
 import {getSatelliteActor} from './actor.api';
@@ -142,16 +143,13 @@ export const listAssets = async ({
 
 export const deleteAsset = async ({
   collection,
-  asset,
+  fullPath,
   satellite
 }: {
   collection: string;
-  asset: Asset;
   satellite: Satellite;
-}): Promise<void> => {
+} & Pick<AssetKey, 'fullPath'>): Promise<void> => {
   const actor: SatelliteActor = await getSatelliteActor(satellite);
-
-  const {fullPath} = asset;
 
   return actor.del_asset(collection, fullPath);
 };

--- a/packages/core/src/services/storage.services.ts
+++ b/packages/core/src/services/storage.services.ts
@@ -119,17 +119,17 @@ export const listAssets = async ({
 };
 
 export const deleteAsset = async ({
-  storageFile,
+  asset,
   collection,
   satellite
 }: {
-  storageFile: Asset;
+  asset: Asset;
   collection: string;
   satellite?: SatelliteOptions;
 }): Promise<void> =>
   deleteAssetApi({
     collection,
-    storageFile,
+    asset,
     satellite: {...satellite, identity: getIdentity(satellite?.identity)}
   });
 

--- a/packages/core/src/services/storage.services.ts
+++ b/packages/core/src/services/storage.services.ts
@@ -119,17 +119,16 @@ export const listAssets = async ({
 };
 
 export const deleteAsset = async ({
-  asset,
   collection,
+  fullPath,
   satellite
 }: {
-  asset: Asset;
   collection: string;
   satellite?: SatelliteOptions;
-}): Promise<void> =>
+} & Pick<AssetKey, 'fullPath'>): Promise<void> =>
   deleteAssetApi({
     collection,
-    asset,
+    fullPath,
     satellite: {...satellite, identity: getIdentity(satellite?.identity)}
   });
 


### PR DESCRIPTION
For consistency reason and because the storage does not check for timestamp when writing and deleting.
Last operation wins unlike in the Datastore.