### PR TITLE
chore(release): clean-up version numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@junobuild/juno-js",
-  "version": "0.0.169",
+  "version": "0.0.170",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@junobuild/juno-js",
-      "version": "0.0.169",
+      "version": "0.0.170",
       "license": "MIT",
       "workspaces": [
         "packages/utils",
@@ -9232,7 +9232,7 @@
     },
     "packages/admin": {
       "name": "@junobuild/admin",
-      "version": "0.6.8",
+      "version": "1.0.0",
       "license": "MIT",
       "peerDependencies": {
         "@dfinity/agent": "^2.3.0",
@@ -9248,7 +9248,7 @@
     },
     "packages/analytics": {
       "name": "@junobuild/analytics",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "isbot": "^5.1.28",
@@ -9288,7 +9288,7 @@
     },
     "packages/cdn": {
       "name": "@junobuild/cdn",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "peerDependencies": {
         "@dfinity/agent": "^2.3.0",
@@ -9304,7 +9304,7 @@
     },
     "packages/cli-tools": {
       "name": "@junobuild/cli-tools",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "file-type": "^21.0.0",
@@ -9341,7 +9341,7 @@
     },
     "packages/config": {
       "name": "@junobuild/config",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "peerDependencies": {
         "@dfinity/zod-schemas": "1.0.0",
@@ -9350,7 +9350,7 @@
     },
     "packages/config-loader": {
       "name": "@junobuild/config-loader",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "peerDependencies": {
         "@babel/core": "^7.28.0",
@@ -9361,7 +9361,7 @@
     },
     "packages/core": {
       "name": "@junobuild/core",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@junobuild/errors": "*",
@@ -9379,7 +9379,7 @@
     },
     "packages/core-peer": {
       "name": "@junobuild/core-peer",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@junobuild/storage": "*",
@@ -9396,7 +9396,7 @@
     },
     "packages/core-standalone": {
       "name": "@junobuild/core-standalone",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@dfinity/agent": "^2.3.0",
@@ -9411,7 +9411,7 @@
     },
     "packages/did-tools": {
       "name": "@junobuild/did-tools",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "peerDependencies": {
         "@babel/core": "^7.28.0",
@@ -9430,7 +9430,7 @@
     },
     "packages/functions": {
       "name": "@junobuild/functions",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "peerDependencies": {
         "@dfinity/agent": "^2.3.0",
@@ -9443,7 +9443,7 @@
     },
     "packages/storage": {
       "name": "@junobuild/storage",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "peerDependencies": {
         "@dfinity/agent": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junobuild/juno-js",
-  "version": "0.0.169",
+  "version": "0.0.170",
   "description": "JavaScript libraries for interfacing with Juno",
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junobuild/admin",
-  "version": "0.6.8",
+  "version": "1.0.0",
   "description": "A library for interfacing with admin features of Juno",
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junobuild/analytics",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Tracker for Juno analytics",
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",

--- a/packages/cdn/package.json
+++ b/packages/cdn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junobuild/cdn",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A toolkit for working with modules that implement Juno's CDN functionality",
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junobuild/cli-tools",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A collection of tools for Juno CLIs and Plugins.",
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junobuild/config-loader",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Utilities for reading Juno's configuration settings.",
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junobuild/config",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Configuration options for Juno CLI",
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",

--- a/packages/core-peer/package.json
+++ b/packages/core-peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junobuild/core-peer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "JavaScript core client for Juno minus DFINITY agent-js dependencies",
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",

--- a/packages/core-standalone/package.json
+++ b/packages/core-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junobuild/core-standalone",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "JavaScript core client for Juno with all dependencies bundled — no peer dependencies",
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junobuild/core",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "JavaScript core client for Juno",
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",

--- a/packages/did-tools/package.json
+++ b/packages/did-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junobuild/did-tools",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Tools for generating APIs from DID files.",
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junobuild/functions",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "JavaScript and TypeScript utilities for Juno Serverless Functions",
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junobuild/storage",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A library for interfacing with Juno's Storage features.",
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",


### PR DESCRIPTION
There were hiccups in last release. Some version were already released so let's bump numbers for clean release.

https://github.com/junobuild/juno-js/actions/runs/16716324737