### PR TITLE
feat(repo): replace URL.parse with new URL to support old Android devices

### DIFF
--- a/packages/analytics/src/tracker.ts
+++ b/packages/analytics/src/tracker.ts
@@ -105,16 +105,16 @@ export const setPageView = async () => {
       return href;
     }
 
-    const url = URL.parse(href);
+    try {
+      const url = new URL(href);
 
-    // Unlikely to happen
-    if (isNullish(url)) {
+      Object.keys(campaignData ?? {}).forEach((key) => url.searchParams.delete(key));
+
+      return url.href;
+    } catch {
+      // Unlikely to happen
       return href;
     }
-
-    Object.keys(campaignData ?? {}).forEach((key) => url.searchParams.delete(key));
-
-    return url.href;
   };
 
   const page_view: SetPageViewPayload = {

--- a/packages/core/src/auth/providers/internet-identity.providers.ts
+++ b/packages/core/src/auth/providers/internet-identity.providers.ts
@@ -88,11 +88,19 @@ export class InternetIdentityProvider extends AuthClientProvider {
     };
 
     const identityProvider = identityProviderUrl();
-    const iiDesignV2 = URL.parse(identityProvider)?.hostname?.includes(ID_AI) === true;
+
+    const iiDesignV2 = (): boolean => {
+      try {
+        const {hostname} = new URL(identityProvider);
+        return hostname.includes(ID_AI);
+      } catch {
+        return false;
+      }
+    };
 
     return {
       ...(windowed !== false && {
-        windowOpenerFeatures: popupCenter(iiDesignV2 ? II_DESIGN_V2_POPUP : II_DESIGN_V1_POPUP)
+        windowOpenerFeatures: popupCenter(iiDesignV2() ? II_DESIGN_V2_POPUP : II_DESIGN_V1_POPUP)
       }),
       identityProvider
     };

--- a/packages/ic-client/src/tests/webauthn/_options.spec.ts
+++ b/packages/ic-client/src/tests/webauthn/_options.spec.ts
@@ -86,14 +86,16 @@ describe('_options', () => {
       expect(onlyDisplay.user.name).toBe('Alex Chen');
     });
 
-    it('should throws WebAuthnHostnameError when URL.parse fails', () => {
-      const spy = vi
-        .spyOn(URL as unknown as {parse(href: string): URL | null}, 'parse')
-        .mockReturnValue(null as unknown as URL);
+    it('should throws WebAuthnHostnameError when new URL fails', () => {
+      const originalURL = global.URL;
+
+      global.URL = vi.fn(() => {
+        throw new TypeError('Invalid URL');
+      }) as unknown as typeof URL;
 
       expect(() => createPasskeyOptions({})).toThrow(WebAuthnIdentityHostnameError);
 
-      spy.mockRestore();
+      global.URL = originalURL;
     });
   });
 
@@ -113,14 +115,16 @@ describe('_options', () => {
       expect(opts.rpId).toBe('myapp.com');
     });
 
-    it('throws WebAuthnHostnameError when URL.parse fails', () => {
-      const spy = vi
-        .spyOn(URL as unknown as {parse(href: string): URL | null}, 'parse')
-        .mockReturnValue(null as unknown as URL);
+    it('throws WebAuthnHostnameError when new URL fails', () => {
+      const originalURL = global.URL;
+
+      global.URL = vi.fn(() => {
+        throw new TypeError('Invalid URL');
+      }) as unknown as typeof URL;
 
       expect(() => retrievePasskeyOptions({})).toThrow(WebAuthnIdentityHostnameError);
 
-      spy.mockRestore();
+      global.URL = originalURL;
     });
   });
 });

--- a/packages/ic-client/src/webauthn/_options.ts
+++ b/packages/ic-client/src/webauthn/_options.ts
@@ -1,4 +1,3 @@
-import {isNullish} from '@dfinity/utils';
 import {PUBLIC_KEY_COSE_ALGORITHMS} from './_constants';
 import {WebAuthnIdentityHostnameError} from './errors';
 import type {CreatePasskeyOptions, PasskeyOptions} from './types/passkey';
@@ -29,15 +28,12 @@ const hostname = (): string => {
     location: {href}
   } = window;
 
-  const url = URL.parse(href);
-
-  if (isNullish(url)) {
+  try {
+    const {hostname} = new URL(href);
+    return hostname;
+  } catch {
     throw new WebAuthnIdentityHostnameError();
   }
-
-  const {hostname} = url;
-
-  return hostname;
 };
 
 const relyingPartyId = ({appId}: Pick<PasskeyOptions, 'appId'>): string => appId?.id ?? hostname();


### PR DESCRIPTION
Old Android devices, notably Android 13, does not support `URL.parse`. Therefore, for backwards compatibility we replace it with `new URL` pattern.