### PR TITLE
feat(auth): return type result (user or mission_control) of the authentication

### DIFF
--- a/packages/auth/src/authenticate.ts
+++ b/packages/auth/src/authenticate.ts
@@ -6,13 +6,16 @@ import {
   AuthenticationUndefinedJwtError,
   AuthenticationUrlHashError
 } from './errors';
-import type {AuthParameters} from './types/actor';
-import type {AuthenticatedIdentity, AuthenticationParams} from './types/authenticate';
+import type {
+  AuthenticatedSession,
+  AuthenticationParams,
+  AuthParameters
+} from './types/authenticate';
 import type {OpenIdAuthContext} from './types/context';
 
-export const authenticate = async (
-  params: AuthenticationParams
-): Promise<AuthenticatedIdentity> => {
+export const authenticate = async <T extends AuthParameters>(
+  params: AuthenticationParams<T>
+): Promise<AuthenticatedSession<T>> => {
   const context = loadContext();
 
   if ('credentials' in params) {
@@ -28,16 +31,16 @@ export const authenticate = async (
     });
   }
 
-  return await authenticateWithRedirect({...params, context});
+  return await authenticateWithRedirect<T>({...params, context});
 };
 
-const authenticateWithRedirect = async ({
+const authenticateWithRedirect = async <T extends AuthParameters>({
   auth,
   context
 }: {
   auth: AuthParameters;
   context: OpenIdAuthContext;
-}): Promise<AuthenticatedIdentity> => {
+}): Promise<AuthenticatedSession<T>> => {
   const {
     location: {hash}
   } = window;

--- a/packages/auth/src/test/mocks/doc.mock.ts
+++ b/packages/auth/src/test/mocks/doc.mock.ts
@@ -1,0 +1,11 @@
+import {Principal} from '@icp-sdk/core/principal';
+import type {SatelliteDid} from '@junobuild/ic-client/actor';
+
+export const mockUserDoc: SatelliteDid.Doc = {
+  updated_at: 1n,
+  owner: Principal.anonymous(),
+  data: new Uint8Array([4, 5, 6]),
+  description: [],
+  created_at: 2n,
+  version: []
+};

--- a/packages/auth/src/types/actor.ts
+++ b/packages/auth/src/types/actor.ts
@@ -1,24 +1,6 @@
 import type {Identity} from '@icp-sdk/core/agent';
-import type {
-  ConsoleDid,
-  ConsoleParameters,
-  SatelliteDid,
-  SatelliteParameters
-} from '@junobuild/ic-client/actor';
-
-/**
- * Represents initialization parameters for either a Console or Satellite actor.
- * Use discriminated unions to pass the correct parameters depending on the authentication to target.
- */
-export type AuthParameters =
-  | {
-      console: Omit<ConsoleParameters, 'consoleId' | 'identity'> &
-        Required<Pick<ConsoleParameters, 'consoleId'>>;
-    }
-  | {
-      satellite: Omit<SatelliteParameters, 'satelliteId' | 'identity'> &
-        Required<Pick<SatelliteParameters, 'satelliteId'>>;
-    };
+import type {ConsoleDid, SatelliteDid} from '@junobuild/ic-client/actor';
+import type {AuthParameters} from './authenticate';
 
 export interface ActorParameters {
   auth: AuthParameters;
@@ -30,3 +12,6 @@ export type GetDelegationArgs = SatelliteDid.GetDelegationArgs | ConsoleDid.GetD
 export type AuthenticationResult = SatelliteDid.AuthenticateResultResponse | ConsoleDid.Result;
 export type GetDelegationResult = SatelliteDid.GetDelegationResultResponse | ConsoleDid.Result_1;
 export type SignedDelegation = SatelliteDid.SignedDelegation | ConsoleDid.SignedDelegation;
+export type AuthenticationData<T extends AuthParameters> = T extends {satellite: unknown}
+  ? Pick<SatelliteDid.Authentication, 'doc'>
+  : Pick<ConsoleDid.Authentication, 'mission_control'>;

--- a/packages/auth/src/types/authenticate.ts
+++ b/packages/auth/src/types/authenticate.ts
@@ -1,16 +1,35 @@
 import type {DelegationChain, DelegationIdentity, ECDSAKeyIdentity} from '@icp-sdk/core/identity';
-import type {AuthParameters} from './actor';
+import type {ConsoleParameters, SatelliteParameters} from '@junobuild/ic-client/actor';
+import type {AuthenticationData} from './actor';
 
 export interface AuthenticationCredentials {
   jwt: string;
 }
 
-export type AuthenticationParams =
-  | {redirect: null; auth: AuthParameters}
-  | {credentials: AuthenticationCredentials; auth: AuthParameters};
+export type AuthenticationParams<T extends AuthParameters = AuthParameters> =
+  | {redirect: null; auth: T}
+  | {credentials: AuthenticationCredentials; auth: T};
 
 export interface AuthenticatedIdentity {
   identity: DelegationIdentity;
   delegationChain: DelegationChain;
   sessionKey: ECDSAKeyIdentity;
+}
+
+/**
+ * Represents initialization parameters for either a Console or Satellite actor.
+ */
+export type AuthParameters =
+  | {
+      console: Omit<ConsoleParameters, 'consoleId' | 'identity'> &
+        Required<Pick<ConsoleParameters, 'consoleId'>>;
+    }
+  | {
+      satellite: Omit<SatelliteParameters, 'satelliteId' | 'identity'> &
+        Required<Pick<SatelliteParameters, 'satelliteId'>>;
+    };
+
+export interface AuthenticatedSession<T extends AuthParameters> {
+  identity: AuthenticatedIdentity;
+  data: AuthenticationData<T>;
 }


### PR DESCRIPTION
Use generic and extends to get the typed result data of the authentication (either user doc in case of Satellite or mission control for the Console).