### PR TITLE
fix(core): type ExcludeDate<() => string> has no call signatures

### DIFF
--- a/packages/core/src/core/types/utility.ts
+++ b/packages/core/src/core/types/utility.ts
@@ -1,3 +1,20 @@
-export type ExcludeDate<T> = {
-  [K in keyof T]: T[K] extends Date ? never : T[K] extends object ? ExcludeDate<T[K]> : T[K];
-};
+type Primitive = string | number | boolean | bigint | symbol | null | undefined;
+
+export type ExcludeDate<T> =
+  // drop Date
+  T extends Date
+    ? never
+    : // keep functions callable
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      T extends (...args: any) => any
+      ? T
+      : // keep primitives as-is
+        T extends Primitive
+        ? T
+        : // preserve arrays
+          T extends Array<infer U>
+          ? ExcludeDate<U>[]
+          : // recurse into plain objects/classes
+            T extends object
+            ? {[K in keyof T]: ExcludeDate<T[K]>}
+            : T;


### PR DESCRIPTION
Spotted a TS issue in `expect(result.data.owner.toText()).toBe(mockUserIdText);`

> TS2349: This expression is not callable.
> Type ExcludeDate<() => string> has no call signatures.