### PR TITLE
feat(functions-tools)!: emit `#[json_data(nested)]` attribute for `Vec` of nested structs

### DIFF
--- a/packages/functions-tools/src/converters/zod-to-rust.ts
+++ b/packages/functions-tools/src/converters/zod-to-rust.ts
@@ -111,7 +111,7 @@ const schemaToRustType = ({
       const inner = schemaToRustType({schema: schema.inner, structName});
       const fieldType = `Vec<${inner.fieldType}>`;
       return inner.kind === 'composite'
-        ? composite({fieldType, structs: inner.structs, needsJsonData: false})
+        ? composite({fieldType, structs: inner.structs, needsJsonData: inner.needsJsonData})
         : primitive({fieldType});
     }
 

--- a/packages/functions-tools/src/tests/converters/zod-to-rust.spec.ts
+++ b/packages/functions-tools/src/tests/converters/zod-to-rust.spec.ts
@@ -185,7 +185,7 @@ describe('object with array field', () => {
     z.object({headers: z.array(z.object({name: z.string(), value: z.string()}))}),
     [
       '#[derive(CandidType, Serialize, Deserialize, Clone, JsonData)]\npub struct MyFunctionArgsHeaders {\n    pub name: String,\n    pub value: String,\n}',
-      '#[derive(CandidType, Serialize, Deserialize, Clone, JsonData)]\npub struct MyFunctionArgs {\n    pub headers: Vec<MyFunctionArgsHeaders>,\n}'
+      '#[derive(CandidType, Serialize, Deserialize, Clone, JsonData)]\npub struct MyFunctionArgs {\n    #[json_data(nested)]\n    pub headers: Vec<MyFunctionArgsHeaders>,\n}'
     ].join('\n\n')
   );
 });


### PR DESCRIPTION
Relates to junobuild/juno#2815

Same as junobuild/juno-js#885 but for the `vec` case. It also needs a change in the `JsonData` derive macro (`junobuild/juno`) to handle a nested `Vec`, and making `vec` camelCase is breaking so it probably wants to be opt-in or a major.
